### PR TITLE
refactor: replace Subscribe with WaitForData, extract Offset and StreamConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ API.md
 
 # Test artifacts
 coverage.out
+history
 
 # Task runner cache
 .task/

--- a/durablestream/client_internal_test.go
+++ b/durablestream/client_internal_test.go
@@ -77,10 +77,6 @@ func (m *mockStorage) Append(_ context.Context, _ string, _ []byte, _ string) (O
 	return "", nil
 }
 
-func (m *mockStorage) AppendFrom(_ context.Context, _ string, _ io.Reader, _ string) (Offset, error) {
-	return "", nil
-}
-
 func (m *mockStorage) Read(_ context.Context, _ string, _ Offset, _ int) (*ReadResult, error) {
 	return &ReadResult{Messages: nil}, nil
 }
@@ -93,8 +89,13 @@ func (m *mockStorage) Delete(_ context.Context, _ string) error {
 	return nil
 }
 
-func (m *mockStorage) Subscribe(_ context.Context, _ string, _ Offset) (<-chan Offset, error) {
-	return nil, nil
+func (m *mockStorage) WaitForData(_ context.Context, _ string, _ Offset, _ int) (*ReadResult, error) {
+	// Mock simply delegates to Read behavior - returns empty result
+	return &ReadResult{Messages: nil}, nil
+}
+
+func (m *mockStorage) Close() error {
+	return nil
 }
 
 func TestHandler_Config(t *testing.T) {

--- a/durablestream/config.go
+++ b/durablestream/config.go
@@ -1,0 +1,44 @@
+package durablestream
+
+import (
+	"strings"
+	"time"
+)
+
+// Matches checks if two StreamConfigs are equivalent for idempotent create.
+// Content-Type is compared case-insensitively (per RFC 2045).
+// ExpiresAt is only compared when TTL is zero (i.e., explicit Stream-Expires-At header).
+func (c StreamConfig) Matches(other StreamConfig) bool {
+	// Content-Type media types are case-insensitive per RFC 2045
+	if !contentTypesMatch(c.ContentType, other.ContentType) {
+		return false
+	}
+	if c.TTL != other.TTL {
+		return false
+	}
+	// Only compare ExpiresAt directly when TTL isn't set (i.e., explicit Stream-Expires-At header).
+	// When TTL is set, ExpiresAt is derived from TTL at request time and will differ between requests.
+	if c.TTL == 0 && other.TTL == 0 && !c.ExpiresAt.Equal(other.ExpiresAt) {
+		return false
+	}
+	if c.IsPrivate != other.IsPrivate {
+		return false
+	}
+	return true
+}
+
+// IsExpired checks if the config has expired based on its ExpiresAt field.
+// Returns false if ExpiresAt is zero (no expiry).
+func (c StreamConfig) IsExpired() bool {
+	return !c.ExpiresAt.IsZero() && time.Now().After(c.ExpiresAt)
+}
+
+// contentTypesMatch compares two content types case-insensitively for the base media type.
+// Parameters after the semicolon are ignored.
+func contentTypesMatch(a, b string) bool {
+	partsA := strings.Split(a, ";")
+	partsB := strings.Split(b, ";")
+	mediaTypeA := strings.TrimSpace(partsA[0])
+	mediaTypeB := strings.TrimSpace(partsB[0])
+	return strings.EqualFold(mediaTypeA, mediaTypeB)
+}

--- a/durablestream/handler.go
+++ b/durablestream/handler.go
@@ -373,30 +373,29 @@ func (h *Handler) handleAppend(w http.ResponseWriter, r *http.Request, streamID 
 			seq = ""
 		}
 	} else {
-		// Non-JSON mode: stream directly to storage without buffering entire body.
-		// This is critical for large uploads - avoids memory exhaustion.
-		// Use a counting reader to detect empty bodies and enforce size limits.
-		limitedReader := &limitedCountingReader{
-			r:     r.Body,
-			limit: h.maxAppendSize,
-		}
-
-		nextOffset, err = h.storage.AppendFrom(r.Context(), streamID, limitedReader, seq)
+		// Non-JSON mode: read body and append
+		body, err := io.ReadAll(io.LimitReader(r.Body, h.maxAppendSize+1))
 		if err != nil {
-			writeStorageError(w, err)
+			writeError(w, newError(codeBadRequest, "failed to read request body"))
 			return
 		}
 
-		// Check if body was empty (after streaming) - Section 5.2
+		// Check if body was empty - Section 5.2
 		// Per spec: "Servers MUST reject POST requests with an empty body...with 400 Bad Request"
-		if limitedReader.n == 0 {
+		if len(body) == 0 {
 			writeError(w, newError(codeBadRequest, "empty body not allowed"))
 			return
 		}
 
-		// Check if size limit was exceeded
-		if limitedReader.exceeded {
+		// Check size limit
+		if int64(len(body)) > h.maxAppendSize {
 			writeError(w, newError(codePayloadTooLarge, fmt.Sprintf("request body exceeds maximum size of %d bytes", h.maxAppendSize)))
+			return
+		}
+
+		nextOffset, err = h.storage.Append(r.Context(), streamID, body, seq)
+		if err != nil {
+			writeStorageError(w, err)
 			return
 		}
 	}
@@ -717,17 +716,17 @@ func (h *Handler) handleLongPoll(w http.ResponseWriter, r *http.Request, streamI
 	// Get cursor parameter for CDN collapsing (Section 8.1)
 	clientCursor := r.URL.Query().Get(protocol.QueryCursor)
 
+	// Fetch stream info once at the start - needed for offset=now and ContentType/IsPrivate
+	info, err := h.storage.Head(r.Context(), streamID)
+	if err != nil {
+		writeStorageError(w, err)
+		return
+	}
+
 	// Handle offset=now sentinel (Section 6)
 	// For long-poll, immediately begin waiting (no initial empty response)
 	isOffsetNow := offset == Offset(protocol.OffsetNow)
 	if isOffsetNow {
-		// Get the actual tail offset to wait from
-		info, err := h.storage.Head(r.Context(), streamID)
-		if err != nil {
-			writeStorageError(w, err)
-			return
-		}
-		// Replace "now" with actual tail offset for subscription
 		offset = info.NextOffset
 	}
 
@@ -741,12 +740,6 @@ func (h *Handler) handleLongPoll(w http.ResponseWriter, r *http.Request, streamI
 
 		// If messages available, return immediately
 		if len(result.Messages) > 0 {
-			info, err := h.storage.Head(r.Context(), streamID)
-			if err != nil {
-				writeStorageError(w, err)
-				return
-			}
-
 			setSecurityHeaders(w)
 			w.Header().Set("Content-Type", info.ContentType)
 			w.Header().Set(protocol.HeaderStreamNextOffset, result.NextOffset.String())
@@ -766,7 +759,7 @@ func (h *Handler) handleLongPoll(w http.ResponseWriter, r *http.Request, streamI
 		}
 	}
 
-	// No data available, subscribe and wait
+	// No data available, wait for data to arrive
 	// Use the shorter of the request context deadline or longPollTimeout
 	waitCtx := r.Context()
 	deadline, hasDeadline := r.Context().Deadline()
@@ -785,61 +778,38 @@ func (h *Handler) handleLongPoll(w http.ResponseWriter, r *http.Request, streamI
 		defer cancel()
 	}
 
-	notifyCh, err := h.storage.Subscribe(waitCtx, streamID, offset)
+	// Wait for data atomically
+	result, err := h.storage.WaitForData(waitCtx, streamID, offset, h.chunkSize)
 	if err != nil {
+		// Timeout - return 204 No Content (per spec Section 5.6)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			setSecurityHeaders(w)
+			w.Header().Set(protocol.HeaderStreamNextOffset, offset.String())
+			w.Header().Set(protocol.HeaderStreamCursor, protocol.GenerateCursor(clientCursor))
+			w.Header().Set(protocol.HeaderStreamUpToDate, "true")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		// Other error (e.g., stream deleted/not found)
 		writeStorageError(w, err)
 		return
 	}
 
-	// Wait for data or timeout
-	select {
-	case _, ok := <-notifyCh:
-		if !ok {
-			// Channel closed (stream deleted or error)
-			writeError(w, newError(codeNotFound, "stream not found"))
-			return
-		}
+	setSecurityHeaders(w)
+	w.Header().Set("Content-Type", info.ContentType)
+	w.Header().Set(protocol.HeaderStreamNextOffset, result.NextOffset.String())
+	w.Header().Set(protocol.HeaderStreamCursor, protocol.GenerateCursor(clientCursor))
+	w.Header().Set("Cache-Control", cacheControlHeader(info.IsPrivate))
 
-		// Data arrived, read and return
-		result, err := h.storage.Read(waitCtx, streamID, offset, h.chunkSize)
-		if err != nil {
-			writeStorageError(w, err)
-			return
-		}
-
-		info, err := h.storage.Head(waitCtx, streamID)
-		if err != nil {
-			writeStorageError(w, err)
-			return
-		}
-
-		setSecurityHeaders(w)
-		w.Header().Set("Content-Type", info.ContentType)
-		w.Header().Set(protocol.HeaderStreamNextOffset, result.NextOffset.String())
-		w.Header().Set(protocol.HeaderStreamCursor, protocol.GenerateCursor(clientCursor))
-		w.Header().Set("Cache-Control", cacheControlHeader(info.IsPrivate))
-
-		// Set Stream-Up-To-Date if at tail (per spec Section 5.6)
-		if result.NextOffset.Compare(result.TailOffset) == 0 {
-			w.Header().Set(protocol.HeaderStreamUpToDate, "true")
-		}
-
-		responseBody := formatResponseBody(result.Messages, info.ContentType)
-
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(responseBody)
-
-	case <-waitCtx.Done():
-		// Timeout - return 204 No Content (per spec Section 5.6)
-		setSecurityHeaders(w)
-		info, err := h.storage.Head(r.Context(), streamID)
-		if err == nil {
-			w.Header().Set(protocol.HeaderStreamNextOffset, info.NextOffset.String())
-		}
-		w.Header().Set(protocol.HeaderStreamCursor, protocol.GenerateCursor(clientCursor))
+	// Set Stream-Up-To-Date if at tail (per spec Section 5.6)
+	if result.NextOffset.Compare(result.TailOffset) == 0 {
 		w.Header().Set(protocol.HeaderStreamUpToDate, "true")
-		w.WriteHeader(http.StatusNoContent)
 	}
+
+	responseBody := formatResponseBody(result.Messages, info.ContentType)
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(responseBody)
 }
 
 // handleSSE implements SSE streaming (Section 5.7)
@@ -891,7 +861,8 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request, streamID str
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	// Set close timer
+	// Set close deadline and timer
+	closeDeadline := time.Now().Add(h.sseCloseAfter)
 	closeTimer := time.NewTimer(h.sseCloseAfter)
 	defer closeTimer.Stop()
 
@@ -909,32 +880,90 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request, streamID str
 	// with upToDate: true even if there's no data.
 	sentInitialControl := isOffsetNow
 
+	// Keepalive interval for sending control events to prevent proxy timeouts
+	const keepaliveInterval = 30 * time.Second
+
 	// Stream loop
 	for {
+		// Check for close/disconnect before blocking
+		select {
+		case <-closeTimer.C:
+			return
+		case <-r.Context().Done():
+			return
+		default:
+		}
+
 		// Try to read data
 		result, err := h.storage.Read(r.Context(), streamID, currentOffset, h.chunkSize)
 		if err != nil {
-			// Connection likely already established, just close
 			return
 		}
 
-		// If messages available, send them
+		// If no messages, wait for data or send keepalive
+		if len(result.Messages) == 0 {
+			// Send initial control if not yet sent (empty stream or starting at tail)
+			if !sentInitialControl {
+				if currentOffset.Compare(result.TailOffset) == 0 || result.NextOffset.Compare(result.TailOffset) == 0 {
+					sentInitialControl = true
+					fmt.Fprintf(w, "event: control\n")
+					fmt.Fprintf(w, "data: {\"streamNextOffset\":\"%s\",\"upToDate\":true,\"streamCursor\":\"%s\"}\n\n", result.NextOffset, protocol.GenerateCursor(clientCursor))
+					flusher.Flush()
+				}
+			}
+
+			// Calculate wait timeout: min of keepalive interval and remaining close time
+			waitTimeout := keepaliveInterval
+			if remaining := time.Until(closeDeadline); remaining < waitTimeout {
+				waitTimeout = remaining
+				if waitTimeout <= 0 {
+					// Close deadline reached
+					return
+				}
+			}
+
+			// Wait for new data - storage handles efficient blocking
+			ctx, cancel := context.WithTimeout(r.Context(), waitTimeout)
+			waitResult, err := h.storage.WaitForData(ctx, streamID, currentOffset, h.chunkSize)
+			cancel()
+
+			if err != nil {
+				// Check if parent context is done (client disconnect)
+				if r.Context().Err() != nil {
+					return
+				}
+				if errors.Is(err, context.DeadlineExceeded) {
+					// Our wait timeout expired - send SSE comment as keepalive to prevent proxy timeout
+					// Per SSE spec, lines starting with ":" are comments and ignored by clients
+					fmt.Fprintf(w, ": keepalive\n\n")
+					flusher.Flush()
+					continue
+				}
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				// Stream deleted or other error
+				return
+			}
+
+			// Reuse waitResult directly instead of re-reading
+			result = waitResult
+		}
+
+		// If we have messages, send them
 		if len(result.Messages) > 0 {
-			sentInitialControl = true // We're sending events now
+			sentInitialControl = true
 
 			// Send data event
 			fmt.Fprintf(w, "event: data\n")
 
 			if protocol.IsJSONContentType(info.ContentType) {
-				// For JSON, format as single-line array
-				// (SSE joins data: lines with \n which would create invalid JSON)
 				jsonArray := formatResponseBody(result.Messages, info.ContentType)
 				fmt.Fprintf(w, "data: %s\n", string(jsonArray))
 			} else {
 				// For text/*, send concatenated data split by lines.
 				// Per SSE spec, lines can be terminated by CR, LF, or CRLF.
-				// We must split by all terminators to prevent CRLF injection attacks
-				// where embedded CR characters could be interpreted as line terminators.
+				// We must split by all terminators to prevent CRLF injection attacks.
 				data := concatenateMessages(result.Messages)
 				lines := splitBySSELineTerminators(string(data))
 				for _, line := range lines {
@@ -943,8 +972,7 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request, streamID str
 			}
 			fmt.Fprintf(w, "\n")
 
-			// Send control event with generated cursor (Section 8.1)
-			// Include upToDate: true if we're at the tail
+			// Send control event with cursor
 			fmt.Fprintf(w, "event: control\n")
 			if result.NextOffset.Compare(result.TailOffset) == 0 {
 				fmt.Fprintf(w, "data: {\"streamNextOffset\":\"%s\",\"upToDate\":true,\"streamCursor\":\"%s\"}\n\n", result.NextOffset, protocol.GenerateCursor(clientCursor))
@@ -953,53 +981,7 @@ func (h *Handler) handleSSE(w http.ResponseWriter, r *http.Request, streamID str
 			}
 
 			flusher.Flush()
-
 			currentOffset = result.NextOffset
-		} else if !sentInitialControl {
-			// No messages and haven't sent initial control yet.
-			// Check if we're at tail (caught up) and send control with upToDate: true.
-			// This handles the case of SSE on an empty stream or starting from tail.
-			if currentOffset.Compare(result.TailOffset) == 0 || result.NextOffset.Compare(result.TailOffset) == 0 {
-				sentInitialControl = true
-				fmt.Fprintf(w, "event: control\n")
-				fmt.Fprintf(w, "data: {\"streamNextOffset\":\"%s\",\"upToDate\":true,\"streamCursor\":\"%s\"}\n\n", result.NextOffset, protocol.GenerateCursor(clientCursor))
-				flusher.Flush()
-			}
-		}
-
-		// Check if we should close
-		select {
-		case <-closeTimer.C:
-			// Close after timeout (Section 5.7)
-			return
-		case <-r.Context().Done():
-			// Client disconnected
-			return
-		default:
-			// Continue, but wait for new data
-			if len(result.Messages) == 0 {
-				// Subscribe and wait for new data
-				ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-				notifyCh, err := h.storage.Subscribe(ctx, streamID, currentOffset)
-				if err != nil {
-					cancel()
-					return
-				}
-
-				select {
-				case <-notifyCh:
-					// New data available, loop will read it
-				case <-closeTimer.C:
-					cancel()
-					return
-				case <-r.Context().Done():
-					cancel()
-					return
-				case <-ctx.Done():
-					// Short timeout, loop again
-				}
-				cancel()
-			}
 		}
 	}
 }
@@ -1232,24 +1214,6 @@ func sanitizeForETag(s string) string {
 		}
 	}
 	return buf.String()
-}
-
-// limitedCountingReader wraps an io.Reader to count bytes read and enforce a size limit.
-// Unlike io.LimitReader, it tracks whether the limit was exceeded rather than just stopping.
-type limitedCountingReader struct {
-	r        io.Reader
-	limit    int64
-	n        int64 // bytes read so far
-	exceeded bool  // true if limit was exceeded
-}
-
-func (l *limitedCountingReader) Read(p []byte) (n int, err error) {
-	n, err = l.r.Read(p)
-	l.n += int64(n)
-	if l.n > l.limit {
-		l.exceeded = true
-	}
-	return n, err
 }
 
 // validateOffset validates an offset string per protocol Section 6 and 10.2.

--- a/durablestream/memorystorage/storage.go
+++ b/durablestream/memorystorage/storage.go
@@ -4,10 +4,7 @@ package memorystorage
 import (
 	"context"
 	"fmt"
-	"io"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/ahimsalabs/durable-streams-go/durablestream"
 	"github.com/go4org/hashtriemap"
@@ -15,11 +12,12 @@ import (
 
 // memoryStream represents a single stream in memory.
 type memoryStream struct {
-	mu          sync.RWMutex // Per-stream lock for mutations
-	config      durablestream.StreamConfig
-	messages    []durablestream.StoredMessage // All messages in order
-	lastSeq     string                        // Last sequence number seen (lexicographic)
-	subscribers []chan durablestream.Offset
+	mu       sync.RWMutex // Per-stream lock for mutations
+	config   durablestream.StreamConfig
+	messages []durablestream.StoredMessage // All messages in order
+	lastSeq  string                        // Last sequence number seen (lexicographic)
+	notifyCh chan struct{}                 // Closed on append, replaced with new channel
+	deleted  bool                          // True if stream has been deleted
 }
 
 // Storage is an in-memory implementation of durablestream.Storage.
@@ -37,22 +35,30 @@ func New() *Storage {
 // Create creates a new stream (Section 5.1).
 func (m *Storage) Create(ctx context.Context, streamID string, cfg durablestream.StreamConfig) (bool, error) {
 	stream := &memoryStream{
-		config:      cfg,
-		messages:    make([]durablestream.StoredMessage, 0),
-		lastSeq:     "",
-		subscribers: make([]chan durablestream.Offset, 0),
+		config:   cfg,
+		messages: make([]durablestream.StoredMessage, 0),
+		lastSeq:  "",
+		notifyCh: make(chan struct{}),
 	}
 
 	existing, loaded := m.streams.LoadOrStore(streamID, stream)
 	if loaded {
 		// Stream already exists - check if it's expired
-		if isExpired(existing.config) {
+		if existing.config.IsExpired() {
+			// Wake any waiters on the old stream before replacing
+			existing.mu.Lock()
+			if !existing.deleted {
+				existing.deleted = true
+				close(existing.notifyCh)
+			}
+			existing.mu.Unlock()
+
 			// Expired stream can be replaced (Section 5.1)
 			m.streams.Store(streamID, stream)
 			return true, nil
 		}
 		// Not expired - check if config matches for idempotency
-		if configsMatch(existing.config, cfg) {
+		if existing.config.Matches(cfg) {
 			return false, nil // Not newly created, but config matches
 		}
 		return false, fmt.Errorf("stream exists with different config: %w", durablestream.ErrConflict)
@@ -76,7 +82,7 @@ func (m *Storage) Append(ctx context.Context, streamID string, data []byte, seq 
 	defer stream.mu.Unlock()
 
 	// Check expiry
-	if isExpired(stream.config) {
+	if stream.config.IsExpired() {
 		return "", durablestream.ErrNotFound
 	}
 
@@ -89,35 +95,22 @@ func (m *Storage) Append(ctx context.Context, streamID string, data []byte, seq 
 	}
 
 	// Create new message with offset
-	offset := formatOffset(len(stream.messages) + 1)
+	// Copy data to ensure durability - caller may reuse/mutate the slice
+	b := make([]byte, len(data))
+	copy(b, data)
+
+	offset := durablestream.FormatOffset(int64(len(stream.messages) + 1))
 	msg := durablestream.StoredMessage{
-		Data:   data,
+		Data:   b,
 		Offset: offset,
 	}
 	stream.messages = append(stream.messages, msg)
 
-	// Notify subscribers (non-blocking)
-	for _, ch := range stream.subscribers {
-		select {
-		case ch <- offset:
-		default:
-		}
-	}
+	// Notify waiters: close current channel to wake all waiters, then replace it
+	close(stream.notifyCh)
+	stream.notifyCh = make(chan struct{})
 
 	return offset, nil
-}
-
-// AppendFrom streams data from an io.Reader to a stream.
-// For Storage, this reads all data into memory then appends.
-// A production storage would stream directly to disk/network.
-func (m *Storage) AppendFrom(ctx context.Context, streamID string, r io.Reader, seq string) (durablestream.Offset, error) {
-	// For memory storage, we still need to read into memory
-	// A real implementation would stream to disk
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return "", fmt.Errorf("failed to read request body: %w", durablestream.ErrBadRequest)
-	}
-	return m.Append(ctx, streamID, data, seq)
 }
 
 // Read returns messages from offset (Section 5.5).
@@ -131,12 +124,12 @@ func (m *Storage) Read(ctx context.Context, streamID string, offset durablestrea
 	defer stream.mu.RUnlock()
 
 	// Check expiry
-	if isExpired(stream.config) {
+	if stream.config.IsExpired() {
 		return nil, durablestream.ErrNotFound
 	}
 
 	// Parse offset to message index
-	offsetIdx, err := parseOffset(offset)
+	offsetIdx, err := durablestream.ParseOffset(offset)
 	if err != nil {
 		return nil, err
 	}
@@ -144,14 +137,14 @@ func (m *Storage) Read(ctx context.Context, streamID string, offset durablestrea
 	// Offset 0 means "start", which maps to first message (index 0)
 	// Offset N means "after message N", so we start reading from index N
 	// If offsetIdx > len(messages), client is ahead of stream (gone)
-	if offsetIdx < 0 || offsetIdx > len(stream.messages) {
+	if offsetIdx > int64(len(stream.messages)) {
 		return nil, durablestream.ErrGone
 	}
 
 	// Collect messages starting from offsetIdx, respecting byte limit
 	var messages []durablestream.StoredMessage
 	totalBytes := 0
-	for i := offsetIdx; i < len(stream.messages); i++ {
+	for i := int(offsetIdx); i < len(stream.messages); i++ {
 		msg := stream.messages[i]
 		if limit > 0 && totalBytes+len(msg.Data) > limit && len(messages) > 0 {
 			// Would exceed limit and we have at least one message
@@ -171,7 +164,7 @@ func (m *Storage) Read(ctx context.Context, streamID string, offset durablestrea
 		// No messages returned, stay at current offset
 		nextOffset = offset
 		if nextOffset == "" || nextOffset == "-1" {
-			nextOffset = formatOffset(0)
+			nextOffset = durablestream.FormatOffset(0)
 		}
 	}
 
@@ -180,7 +173,7 @@ func (m *Storage) Read(ctx context.Context, streamID string, offset durablestrea
 	if len(stream.messages) > 0 {
 		tailOffset = stream.messages[len(stream.messages)-1].Offset
 	} else {
-		tailOffset = formatOffset(0)
+		tailOffset = durablestream.FormatOffset(0)
 	}
 
 	return &durablestream.ReadResult{
@@ -201,7 +194,7 @@ func (m *Storage) Head(ctx context.Context, streamID string) (*durablestream.Str
 	defer stream.mu.RUnlock()
 
 	// Check expiry
-	if isExpired(stream.config) {
+	if stream.config.IsExpired() {
 		return nil, durablestream.ErrNotFound
 	}
 
@@ -210,7 +203,7 @@ func (m *Storage) Head(ctx context.Context, streamID string) (*durablestream.Str
 	if len(stream.messages) > 0 {
 		nextOffset = stream.messages[len(stream.messages)-1].Offset
 	} else {
-		nextOffset = formatOffset(0)
+		nextOffset = durablestream.FormatOffset(0)
 	}
 
 	return &durablestream.StreamInfo{
@@ -229,114 +222,68 @@ func (m *Storage) Delete(ctx context.Context, streamID string) error {
 		return durablestream.ErrNotFound
 	}
 
-	// Close all subscriber channels
+	// Mark as deleted and close notification channel to wake any waiters
 	stream.mu.Lock()
-	for _, ch := range stream.subscribers {
-		close(ch)
-	}
+	stream.deleted = true
+	close(stream.notifyCh)
 	stream.mu.Unlock()
 
 	return nil
 }
 
-// Subscribe returns a channel notified when new data arrives.
-func (m *Storage) Subscribe(ctx context.Context, streamID string, offset durablestream.Offset) (<-chan durablestream.Offset, error) {
-	stream, ok := m.streams.Load(streamID)
-	if !ok {
-		return nil, durablestream.ErrNotFound
-	}
-
-	stream.mu.Lock()
-
-	// Check expiry
-	if isExpired(stream.config) {
-		stream.mu.Unlock()
-		return nil, durablestream.ErrNotFound
-	}
-
-	// Create buffered channel to avoid blocking appends
-	ch := make(chan durablestream.Offset, 10)
-	stream.subscribers = append(stream.subscribers, ch)
-	stream.mu.Unlock()
-
-	// Handle context cancellation
-	go func() {
-		<-ctx.Done()
-
-		// Remove subscriber - stream may have been deleted, so re-check
-		s, ok := m.streams.Load(streamID)
-		if ok {
-			s.mu.Lock()
-			for i, sub := range s.subscribers {
-				if sub == ch {
-					s.subscribers = append(s.subscribers[:i], s.subscribers[i+1:]...)
-					break
-				}
-			}
-			s.mu.Unlock()
+// WaitForData blocks until data is available at offset, then returns it.
+// Returns immediately if data already exists at offset.
+// Returns ctx.Err() on timeout/cancellation.
+// Returns ErrNotFound if stream doesn't exist or is deleted while waiting.
+func (m *Storage) WaitForData(ctx context.Context, streamID string, offset durablestream.Offset, limit int) (*durablestream.ReadResult, error) {
+	for {
+		stream, ok := m.streams.Load(streamID)
+		if !ok {
+			return nil, durablestream.ErrNotFound
 		}
-		close(ch)
-	}()
 
-	return ch, nil
+		stream.mu.RLock()
+
+		// Check if stream is deleted
+		if stream.deleted {
+			stream.mu.RUnlock()
+			return nil, durablestream.ErrNotFound
+		}
+
+		// Check expiry
+		if stream.config.IsExpired() {
+			stream.mu.RUnlock()
+			return nil, durablestream.ErrNotFound
+		}
+
+		// Get notification channel before reading (to avoid race)
+		notifyCh := stream.notifyCh
+
+		stream.mu.RUnlock()
+
+		// Try to read data
+		result, err := m.Read(ctx, streamID, offset, limit)
+		if err != nil {
+			return nil, err
+		}
+
+		// If we have data, return it
+		if len(result.Messages) > 0 {
+			return result, nil
+		}
+
+		// No data available, wait for notification or context cancellation
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-notifyCh:
+			// New data or deletion - loop to re-check
+		}
+	}
 }
 
-// formatOffset formats an offset index as a zero-padded string.
-// Uses 10 digits to support up to 9,999,999,999 offsets.
-// Per Section 6: Offsets must be lexicographically sortable and strictly increasing.
-func formatOffset(idx int) durablestream.Offset {
-	return durablestream.Offset(fmt.Sprintf("%010d", idx))
-}
-
-// parseOffset parses an offset string back to an index.
-// Per Section 6: "-1" is the sentinel value for stream beginning.
-// Special value "-1" is treated as 0 (read from start).
-func parseOffset(offset durablestream.Offset) (int, error) {
-	if offset == "" || offset == "-1" {
-		return 0, nil
-	}
-	var idx int
-	_, err := fmt.Sscanf(string(offset), "%d", &idx)
-	if err != nil {
-		return 0, fmt.Errorf("invalid offset %q: %w", offset, durablestream.ErrBadRequest)
-	}
-	return idx, nil
-}
-
-// configsMatch checks if two StreamConfigs are equivalent for idempotent create.
-func configsMatch(a, b durablestream.StreamConfig) bool {
-	// Content-Type media types are case-insensitive per RFC 2045
-	if !contentTypesMatch(a.ContentType, b.ContentType) {
-		return false
-	}
-	if a.TTL != b.TTL {
-		return false
-	}
-	// Only compare ExpiresAt directly when TTL isn't set (i.e., explicit Stream-Expires-At header).
-	// When TTL is set, ExpiresAt is derived from TTL at request time and will differ between requests.
-	if a.TTL == 0 && b.TTL == 0 && !a.ExpiresAt.Equal(b.ExpiresAt) {
-		return false
-	}
-	if a.IsPrivate != b.IsPrivate {
-		return false
-	}
-	return true
-}
-
-// isExpired checks if a stream has expired based on its config.
-func isExpired(cfg durablestream.StreamConfig) bool {
-	if !cfg.ExpiresAt.IsZero() && time.Now().After(cfg.ExpiresAt) {
-		return true
-	}
-	// TTL is checked at creation time, not on every access in this simple implementation
-	return false
-}
-
-// contentTypesMatch compares two content types case-insensitively for the base media type.
-func contentTypesMatch(a, b string) bool {
-	partsA := strings.Split(a, ";")
-	partsB := strings.Split(b, ";")
-	mediaTypeA := strings.TrimSpace(partsA[0])
-	mediaTypeB := strings.TrimSpace(partsB[0])
-	return strings.EqualFold(mediaTypeA, mediaTypeB)
+// Close releases resources. Safe to call multiple times.
+// For in-memory storage, this is a no-op.
+func (m *Storage) Close() error {
+	return nil
 }

--- a/durablestream/memorystorage/storage_test.go
+++ b/durablestream/memorystorage/storage_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -323,70 +322,31 @@ func TestAppend(t *testing.T) {
 		}
 	})
 
-	t.Run("notifies subscribers", func(t *testing.T) {
+	t.Run("notifies waiters via WaitForData", func(t *testing.T) {
 		s := New()
 		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 
-		ch, _ := s.Subscribe(ctx, "test", "")
-
-		// Append should notify
+		// Append in background
 		go func() {
 			time.Sleep(10 * time.Millisecond)
 			_, _ = s.Append(context.Background(), "test", []byte("data"), "")
 		}()
 
-		select {
-		case offset := <-ch:
-			if offset != "0000000001" {
-				t.Errorf("expected offset 0000000001, got %s", offset)
-			}
-		case <-time.After(100 * time.Millisecond):
-			t.Error("subscriber not notified")
-		}
-	})
-}
-
-func TestAppendFrom(t *testing.T) {
-	t.Run("appends from reader", func(t *testing.T) {
-		s := New()
-		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
-
-		r := strings.NewReader("hello from reader")
-		offset, err := s.AppendFrom(context.Background(), "test", r, "")
+		// Use WaitForData to wait for notification
+		result, err := s.WaitForData(ctx, "test", "", 0)
 		if err != nil {
-			t.Fatalf("append reader: %v", err)
+			t.Fatalf("WaitForData error: %v", err)
 		}
-		if offset != "0000000001" {
-			t.Errorf("expected offset 0000000001, got %s", offset)
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(result.Messages))
 		}
-
-		result, _ := s.Read(context.Background(), "test", "0000000000", 0)
-		if string(concatMessages(result)) != "hello from reader" {
-			t.Errorf("unexpected data: %s", concatMessages(result))
+		if string(result.Messages[0].Data) != "data" {
+			t.Errorf("expected 'data', got %s", result.Messages[0].Data)
 		}
 	})
-
-	t.Run("propagates read errors", func(t *testing.T) {
-		s := New()
-		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
-
-		r := &errorReader{err: errors.New("read failed")}
-		_, err := s.AppendFrom(context.Background(), "test", r, "")
-		if !errors.Is(err, durablestream.ErrBadRequest) {
-			t.Errorf("expected ErrBadRequest, got: %v", err)
-		}
-	})
-}
-
-type errorReader struct {
-	err error
-}
-
-func (r *errorReader) Read(p []byte) (int, error) {
-	return 0, r.err
 }
 
 func TestRead(t *testing.T) {
@@ -533,15 +493,16 @@ func TestRead(t *testing.T) {
 		}
 	})
 
-	t.Run("returns gone for negative offset", func(t *testing.T) {
+	t.Run("returns bad request for negative offset", func(t *testing.T) {
 		s := New()
 		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
 		_, _ = s.Append(context.Background(), "test", []byte("data"), "")
 
-		// -2 is not a valid offset (only -1 is special)
+		// -2 is not a valid offset (only -1 is special sentinel for stream start)
+		// Negative offsets are invalid input, not "gone" (client ahead of stream)
 		_, err := s.Read(context.Background(), "test", "-2", 0)
-		if !errors.Is(err, durablestream.ErrGone) {
-			t.Errorf("expected ErrGone for negative offset, got: %v", err)
+		if !errors.Is(err, durablestream.ErrBadRequest) {
+			t.Errorf("expected ErrBadRequest for negative offset, got: %v", err)
 		}
 	})
 }
@@ -624,161 +585,203 @@ func TestDelete(t *testing.T) {
 		}
 	})
 
-	t.Run("closes subscriber channels", func(t *testing.T) {
+	t.Run("wakes WaitForData callers on delete", func(t *testing.T) {
 		s := New()
 		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
 
-		// Use a long timeout to avoid triggering context cancellation during test
-		// (There's a known issue with double-close if context is cancelled after delete)
-		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
-		_ = cancel // Don't cancel during test
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
 
-		ch, _ := s.Subscribe(ctx, "test", "")
+		// Start WaitForData in goroutine
+		waitDone := make(chan error, 1)
+		go func() {
+			_, err := s.WaitForData(ctx, "test", "", 0)
+			waitDone <- err
+		}()
+
+		// Give waiter time to register
+		time.Sleep(10 * time.Millisecond)
 
 		// Delete the stream
 		_ = s.Delete(context.Background(), "test")
 
-		// Channel should be closed
+		// WaitForData should return ErrNotFound
 		select {
-		case _, ok := <-ch:
-			if ok {
-				// We might receive pending data, wait for close
-				_, ok = <-ch
-			}
-			if ok {
-				t.Error("expected channel to be closed after delete")
+		case err := <-waitDone:
+			if !errors.Is(err, durablestream.ErrNotFound) {
+				t.Errorf("expected ErrNotFound, got: %v", err)
 			}
 		case <-time.After(100 * time.Millisecond):
-			t.Error("channel not closed after delete")
+			t.Error("WaitForData did not return after delete")
 		}
 	})
 }
 
-func TestSubscribe(t *testing.T) {
-	t.Run("subscribes successfully", func(t *testing.T) {
+func TestWaitForData(t *testing.T) {
+	t.Run("returns immediately when data exists", func(t *testing.T) {
 		s := New()
 		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
+		_, _ = s.Append(context.Background(), "test", []byte("existing data"), "")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		ch, err := s.Subscribe(ctx, "test", "")
+		result, err := s.WaitForData(context.Background(), "test", "", 0)
 		if err != nil {
-			t.Fatalf("subscribe: %v", err)
+			t.Fatalf("WaitForData: %v", err)
 		}
-		if ch == nil {
-			t.Fatal("expected channel, got nil")
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(result.Messages))
+		}
+		if string(result.Messages[0].Data) != "existing data" {
+			t.Errorf("unexpected data: %s", result.Messages[0].Data)
 		}
 	})
 
-	t.Run("returns not found for non-existent stream", func(t *testing.T) {
+	t.Run("blocks until data arrives", func(t *testing.T) {
+		s := New()
+		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		// Append in background
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			_, _ = s.Append(context.Background(), "test", []byte("new data"), "")
+		}()
+
+		result, err := s.WaitForData(ctx, "test", "", 0)
+		if err != nil {
+			t.Fatalf("WaitForData: %v", err)
+		}
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(result.Messages))
+		}
+		if string(result.Messages[0].Data) != "new data" {
+			t.Errorf("unexpected data: %s", result.Messages[0].Data)
+		}
+	})
+
+	t.Run("returns ctx.Err on timeout", func(t *testing.T) {
+		s := New()
+		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		_, err := s.WaitForData(ctx, "test", "", 0)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("expected context.DeadlineExceeded, got: %v", err)
+		}
+	})
+
+	t.Run("returns ErrNotFound for non-existent stream", func(t *testing.T) {
 		s := New()
 
-		_, err := s.Subscribe(context.Background(), "nonexistent", "")
+		_, err := s.WaitForData(context.Background(), "nonexistent", "", 0)
 		if !errors.Is(err, durablestream.ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got: %v", err)
 		}
 	})
 
-	t.Run("returns not found for expired stream", func(t *testing.T) {
+	t.Run("returns ErrNotFound for expired stream", func(t *testing.T) {
 		s := New()
 		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{
 			ContentType: "text/plain",
 			ExpiresAt:   time.Now().Add(-time.Hour),
 		})
 
-		_, err := s.Subscribe(context.Background(), "test", "")
+		_, err := s.WaitForData(context.Background(), "test", "", 0)
 		if !errors.Is(err, durablestream.ErrNotFound) {
 			t.Errorf("expected ErrNotFound for expired stream, got: %v", err)
 		}
 	})
 
-	t.Run("unsubscribes on context cancellation", func(t *testing.T) {
+	t.Run("returns ErrNotFound when stream deleted while waiting", func(t *testing.T) {
 		s := New()
 		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
 
-		ctx, cancel := context.WithCancel(context.Background())
-		ch, _ := s.Subscribe(ctx, "test", "")
-
-		// Cancel context
-		cancel()
-
-		// Wait a bit for unsubscribe goroutine to run
-		time.Sleep(50 * time.Millisecond)
-
-		// Channel should be closed
-		select {
-		case _, ok := <-ch:
-			if ok {
-				t.Error("expected channel to be closed after context cancellation")
-			}
-		default:
-			// Channel is empty but might not be closed yet, try again
-			time.Sleep(50 * time.Millisecond)
-			select {
-			case _, ok := <-ch:
-				if ok {
-					t.Error("expected channel to be closed after context cancellation")
-				}
-			default:
-				t.Error("channel not closed after context cancellation")
-			}
-		}
-	})
-
-	t.Run("handles stream deletion while subscribed", func(t *testing.T) {
-		// Test that deleting a stream properly cleans up subscribers.
-		// NOTE: There is a known issue if context is cancelled after stream is
-		// deleted (potential double-close panic). This test avoids that by
-		// using a long-lived context.
-		s := New()
-		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
-
-		// Use a timeout context that won't expire during the test
-		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
-		_ = cancel // Don't cancel during test to avoid double-close
-
-		ch, _ := s.Subscribe(ctx, "test", "")
-
-		// Delete stream - this should close the channel
-		_ = s.Delete(context.Background(), "test")
-
-		// Channel should be closed by delete
-		select {
-		case _, ok := <-ch:
-			if ok {
-				t.Error("expected channel to be closed after delete")
-			}
-		case <-time.After(100 * time.Millisecond):
-			t.Error("channel not closed after delete")
-		}
-	})
-
-	t.Run("non-blocking notification", func(t *testing.T) {
-		s := New()
-		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
-
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 
-		// Subscribe but don't read from channel
-		_, _ = s.Subscribe(ctx, "test", "")
+		// Start WaitForData in goroutine
+		waitDone := make(chan error, 1)
+		go func() {
+			_, err := s.WaitForData(ctx, "test", "", 0)
+			waitDone <- err
+		}()
 
-		// Fill up the channel buffer (size 10)
-		for i := 0; i < 20; i++ {
-			_, err := s.Append(context.Background(), "test", []byte("data"), "")
-			if err != nil {
-				t.Fatalf("append %d: %v", i, err)
+		// Give waiter time to register
+		time.Sleep(10 * time.Millisecond)
+
+		// Delete stream - should wake waiter with ErrNotFound
+		_ = s.Delete(context.Background(), "test")
+
+		select {
+		case err := <-waitDone:
+			if !errors.Is(err, durablestream.ErrNotFound) {
+				t.Errorf("expected ErrNotFound, got: %v", err)
 			}
+		case <-time.After(100 * time.Millisecond):
+			t.Error("WaitForData did not return after delete")
+		}
+	})
+
+	t.Run("respects limit parameter", func(t *testing.T) {
+		s := New()
+		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
+		_, _ = s.Append(context.Background(), "test", []byte("aaaa"), "")
+		_, _ = s.Append(context.Background(), "test", []byte("bbbb"), "")
+		_, _ = s.Append(context.Background(), "test", []byte("cccc"), "")
+
+		// Limit of 6 should return only first message (4 bytes fits, 8 would exceed)
+		result, err := s.WaitForData(context.Background(), "test", "", 6)
+		if err != nil {
+			t.Fatalf("WaitForData: %v", err)
+		}
+		if len(result.Messages) != 1 {
+			t.Errorf("expected 1 message with limit 6, got %d", len(result.Messages))
+		}
+	})
+
+	t.Run("handles concurrent waiters", func(t *testing.T) {
+		s := New()
+		_, _ = s.Create(context.Background(), "test", durablestream.StreamConfig{ContentType: "text/plain"})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		// Start multiple waiters
+		const numWaiters = 5
+		results := make(chan *durablestream.ReadResult, numWaiters)
+		for i := 0; i < numWaiters; i++ {
+			go func() {
+				result, _ := s.WaitForData(ctx, "test", "", 0)
+				results <- result
+			}()
 		}
 
-		// Should not have blocked
+		// Give waiters time to register
+		time.Sleep(10 * time.Millisecond)
+
+		// Single append should wake all waiters
+		_, _ = s.Append(context.Background(), "test", []byte("data"), "")
+
+		// All waiters should receive the data
+		for i := 0; i < numWaiters; i++ {
+			select {
+			case result := <-results:
+				if result == nil || len(result.Messages) != 1 {
+					t.Errorf("waiter %d: expected 1 message", i)
+				}
+			case <-time.After(100 * time.Millisecond):
+				t.Errorf("waiter %d: did not receive data", i)
+			}
+		}
 	})
 }
 
 func TestFormatOffset(t *testing.T) {
 	tests := []struct {
-		idx  int
+		idx  int64
 		want durablestream.Offset
 	}{
 		{0, "0000000000"},
@@ -788,9 +791,9 @@ func TestFormatOffset(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := formatOffset(tt.idx)
+		got := durablestream.FormatOffset(tt.idx)
 		if got != tt.want {
-			t.Errorf("formatOffset(%d) = %s, want %s", tt.idx, got, tt.want)
+			t.Errorf("FormatOffset(%d) = %s, want %s", tt.idx, got, tt.want)
 		}
 	}
 }
@@ -798,7 +801,7 @@ func TestFormatOffset(t *testing.T) {
 func TestParseOffset(t *testing.T) {
 	tests := []struct {
 		offset  durablestream.Offset
-		want    int
+		want    int64
 		wantErr bool
 	}{
 		{"", 0, false},
@@ -806,52 +809,32 @@ func TestParseOffset(t *testing.T) {
 		{"0000000000", 0, false},
 		{"0000000001", 1, false},
 		{"0000000123", 123, false},
-		{"123", 123, false}, // Without zero-padding
+		{"123", 123, false},  // Without zero-padding
+		{"-5", 0, true},      // Negative offset should error
 		{"invalid", 0, true},
 	}
 
 	for _, tt := range tests {
-		got, err := parseOffset(tt.offset)
+		got, err := durablestream.ParseOffset(tt.offset)
 		if tt.wantErr {
 			if err == nil {
-				t.Errorf("parseOffset(%q) expected error, got nil", tt.offset)
+				t.Errorf("ParseOffset(%q) expected error, got nil", tt.offset)
 			}
 		} else {
 			if err != nil {
-				t.Errorf("parseOffset(%q) unexpected error: %v", tt.offset, err)
+				t.Errorf("ParseOffset(%q) unexpected error: %v", tt.offset, err)
 			}
 			if got != tt.want {
-				t.Errorf("parseOffset(%q) = %d, want %d", tt.offset, got, tt.want)
+				t.Errorf("ParseOffset(%q) = %d, want %d", tt.offset, got, tt.want)
 			}
 		}
 	}
 }
 
-func TestContentTypesMatch(t *testing.T) {
-	tests := []struct {
-		a, b string
-		want bool
-	}{
-		{"text/plain", "text/plain", true},
-		{"TEXT/PLAIN", "text/plain", true},
-		{"application/json", "APPLICATION/JSON", true},
-		{"text/plain; charset=utf-8", "text/plain", true},
-		{"text/plain", "text/html", false},
-		{"application/json", "application/xml", false},
-	}
-
-	for _, tt := range tests {
-		got := contentTypesMatch(tt.a, tt.b)
-		if got != tt.want {
-			t.Errorf("contentTypesMatch(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
-		}
-	}
-}
-
-func TestIsExpired(t *testing.T) {
+func TestStreamConfig_IsExpired(t *testing.T) {
 	t.Run("not expired with zero ExpiresAt", func(t *testing.T) {
 		cfg := durablestream.StreamConfig{}
-		if isExpired(cfg) {
+		if cfg.IsExpired() {
 			t.Error("expected not expired with zero ExpiresAt")
 		}
 	})
@@ -860,7 +843,7 @@ func TestIsExpired(t *testing.T) {
 		cfg := durablestream.StreamConfig{
 			ExpiresAt: time.Now().Add(time.Hour),
 		}
-		if isExpired(cfg) {
+		if cfg.IsExpired() {
 			t.Error("expected not expired with future ExpiresAt")
 		}
 	})
@@ -869,13 +852,13 @@ func TestIsExpired(t *testing.T) {
 		cfg := durablestream.StreamConfig{
 			ExpiresAt: time.Now().Add(-time.Hour),
 		}
-		if !isExpired(cfg) {
+		if !cfg.IsExpired() {
 			t.Error("expected expired with past ExpiresAt")
 		}
 	})
 }
 
-func TestConfigsMatch(t *testing.T) {
+func TestStreamConfig_Matches(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
@@ -929,9 +912,9 @@ func TestConfigsMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := configsMatch(tt.a, tt.b)
+			got := tt.a.Matches(tt.b)
 			if got != tt.want {
-				t.Errorf("configsMatch() = %v, want %v", got, tt.want)
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/durablestream/offset.go
+++ b/durablestream/offset.go
@@ -1,6 +1,11 @@
 // Package durablestream implements the Durable Streams Protocol.
 package durablestream
 
+import (
+	"fmt"
+	"strconv"
+)
+
 // Offset represents an opaque position within a stream.
 // Per spec Section 6: Offsets are opaque tokens that are lexicographically sortable.
 //
@@ -44,4 +49,30 @@ func (o Offset) IsZero() bool {
 // Implements fmt.Stringer interface.
 func (o Offset) String() string {
 	return string(o)
+}
+
+// FormatOffset formats an index as a zero-padded 10-digit string offset.
+// This is a helper for storage implementations that use sequential integer offsets.
+// Uses 10 digits to support up to 9,999,999,999 offsets.
+// Per Section 6: Offsets must be lexicographically sortable and strictly increasing.
+func FormatOffset(idx int64) Offset {
+	return Offset(fmt.Sprintf("%010d", idx))
+}
+
+// ParseOffset parses an offset string back to an index.
+// Returns 0 for empty string or "-1" (stream beginning sentinel).
+// Returns ErrBadRequest for invalid or negative offsets.
+// This is a helper for storage implementations that use sequential integer offsets.
+func ParseOffset(offset Offset) (int64, error) {
+	if offset == "" || offset == "-1" {
+		return 0, nil
+	}
+	idx, err := strconv.ParseInt(string(offset), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid offset %q: %w", offset, ErrBadRequest)
+	}
+	if idx < 0 {
+		return 0, fmt.Errorf("negative offset %q: %w", offset, ErrBadRequest)
+	}
+	return idx, nil
 }

--- a/durablestream/storage.go
+++ b/durablestream/storage.go
@@ -2,7 +2,6 @@ package durablestream
 
 import (
 	"context"
-	"io"
 	"time"
 )
 
@@ -47,26 +46,29 @@ type Storage interface {
 
 	// Append writes data to a stream. Returns the new tail offset.
 	// seq is optional sequence number for coordination (Section 5.2).
+	//
+	// The data slice is only valid for the duration of the call; the caller
+	// may reuse or modify it after Append returns. Implementations that need
+	// to retain the data (e.g., in-memory storage) must copy it.
 	Append(ctx context.Context, streamID string, data []byte, seq string) (Offset, error)
-
-	// AppendFrom streams data from an io.Reader to a stream.
-	// This avoids buffering the entire request body in memory.
-	// The reader is read until EOF or error. Returns the new tail offset.
-	// Implementations MUST ensure atomic writes - either all data is persisted
-	// or none (per protocol atomicity requirements).
-	AppendFrom(ctx context.Context, streamID string, r io.Reader, seq string) (Offset, error)
 
 	// Read returns messages from offset. limit is max total bytes to return.
 	// Returns messages and the next offset to read from (Section 5.5).
 	Read(ctx context.Context, streamID string, offset Offset, limit int) (*ReadResult, error)
 
 	// Head returns stream metadata without reading data (Section 5.4).
+	// Returns ErrNotFound if stream doesn't exist (use for existence checks).
 	Head(ctx context.Context, streamID string) (*StreamInfo, error)
 
 	// Delete removes a stream (Section 5.3).
 	Delete(ctx context.Context, streamID string) error
 
-	// Subscribe returns a channel notified when new data arrives after offset.
-	// The channel receives the new tail offset. Closing the context cancels the subscription.
-	Subscribe(ctx context.Context, streamID string, offset Offset) (<-chan Offset, error)
+	// WaitForData blocks until data is available at offset, then returns it.
+	// Returns immediately if data already exists at offset.
+	// Returns ctx.Err() on timeout/cancellation.
+	// Returns ErrNotFound if stream doesn't exist or is deleted while waiting.
+	WaitForData(ctx context.Context, streamID string, offset Offset, limit int) (*ReadResult, error)
+
+	// Close releases resources. Safe to call multiple times.
+	Close() error
 }

--- a/durablestream/storage_mock_test.go
+++ b/durablestream/storage_mock_test.go
@@ -3,7 +3,6 @@ package durablestream
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http/httptest"
 	"sync"
 	"time"
@@ -17,9 +16,10 @@ type testStorage struct {
 }
 
 type testStream struct {
-	config      StreamConfig
-	messages    []StoredMessage
-	subscribers []chan Offset
+	config   StreamConfig
+	messages []StoredMessage
+	notifyCh chan struct{} // Closed on append, replaced with new channel
+	deleted  bool
 }
 
 func newTestStorage() *testStorage {
@@ -39,6 +39,7 @@ func (s *testStorage) Create(ctx context.Context, streamID string, cfg StreamCon
 	stream := &testStream{
 		config:   cfg,
 		messages: make([]StoredMessage, 0),
+		notifyCh: make(chan struct{}),
 	}
 
 	s.streams[streamID] = stream
@@ -54,30 +55,22 @@ func (s *testStorage) Append(ctx context.Context, streamID string, data []byte, 
 		return "", ErrNotFound
 	}
 
-	offset := Offset(fmt.Sprintf("%010d", len(stream.messages)+1))
+	// Copy data - caller may reuse the slice (per Storage interface contract)
+	b := make([]byte, len(data))
+	copy(b, data)
+
+	offset := FormatOffset(int64(len(stream.messages) + 1))
 	msg := StoredMessage{
-		Data:   data,
+		Data:   b,
 		Offset: offset,
 	}
 	stream.messages = append(stream.messages, msg)
 
-	// Notify subscribers
-	for _, ch := range stream.subscribers {
-		select {
-		case ch <- offset:
-		default:
-		}
-	}
+	// Notify waiters: close current channel to wake all waiters, then replace it
+	close(stream.notifyCh)
+	stream.notifyCh = make(chan struct{})
 
 	return offset, nil
-}
-
-func (s *testStorage) AppendFrom(ctx context.Context, streamID string, r io.Reader, seq string) (Offset, error) {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return "", err
-	}
-	return s.Append(ctx, streamID, data, seq)
 }
 
 func (s *testStorage) Read(ctx context.Context, streamID string, offset Offset, limit int) (*ReadResult, error) {
@@ -117,7 +110,7 @@ func (s *testStorage) Read(ctx context.Context, streamID string, offset Offset, 
 	} else {
 		nextOffset = offset
 		if nextOffset == "" || nextOffset == "-1" {
-			nextOffset = Offset(fmt.Sprintf("%010d", 0))
+			nextOffset = FormatOffset(0)
 		}
 	}
 
@@ -126,7 +119,7 @@ func (s *testStorage) Read(ctx context.Context, streamID string, offset Offset, 
 	if len(stream.messages) > 0 {
 		tailOffset = stream.messages[len(stream.messages)-1].Offset
 	} else {
-		tailOffset = Offset(fmt.Sprintf("%010d", 0))
+		tailOffset = FormatOffset(0)
 	}
 
 	return &ReadResult{
@@ -149,7 +142,7 @@ func (s *testStorage) Head(ctx context.Context, streamID string) (*StreamInfo, e
 	if len(stream.messages) > 0 {
 		nextOffset = stream.messages[len(stream.messages)-1].Offset
 	} else {
-		nextOffset = Offset(fmt.Sprintf("%010d", 0))
+		nextOffset = FormatOffset(0)
 	}
 
 	return &StreamInfo{
@@ -169,41 +162,54 @@ func (s *testStorage) Delete(ctx context.Context, streamID string) error {
 		return ErrNotFound
 	}
 
-	for _, ch := range stream.subscribers {
-		close(ch)
-	}
+	// Mark as deleted and close notification channel to wake any waiters
+	stream.deleted = true
+	close(stream.notifyCh)
 	delete(s.streams, streamID)
 	return nil
 }
 
-func (s *testStorage) Subscribe(ctx context.Context, streamID string, offset Offset) (<-chan Offset, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	stream, ok := s.streams[streamID]
-	if !ok {
-		return nil, ErrNotFound
-	}
-
-	ch := make(chan Offset, 10)
-	stream.subscribers = append(stream.subscribers, ch)
-
-	go func() {
-		<-ctx.Done()
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		if st, ok := s.streams[streamID]; ok {
-			for i, sub := range st.subscribers {
-				if sub == ch {
-					st.subscribers = append(st.subscribers[:i], st.subscribers[i+1:]...)
-					break
-				}
-			}
+// WaitForData blocks until data is available at offset, then returns it.
+func (s *testStorage) WaitForData(ctx context.Context, streamID string, offset Offset, limit int) (*ReadResult, error) {
+	for {
+		s.mu.RLock()
+		stream, ok := s.streams[streamID]
+		if !ok {
+			s.mu.RUnlock()
+			return nil, ErrNotFound
 		}
-		close(ch)
-	}()
 
-	return ch, nil
+		if stream.deleted {
+			s.mu.RUnlock()
+			return nil, ErrNotFound
+		}
+
+		notifyCh := stream.notifyCh
+		s.mu.RUnlock()
+
+		// Try to read data
+		result, err := s.Read(ctx, streamID, offset, limit)
+		if err != nil {
+			return nil, err
+		}
+
+		// If we have data, return it
+		if len(result.Messages) > 0 {
+			return result, nil
+		}
+
+		// No data available, wait for notification or context cancellation
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-notifyCh:
+			// New data or deletion - loop to re-check
+		}
+	}
+}
+
+func (s *testStorage) Close() error {
+	return nil
 }
 
 // setupInternalTestServer creates a test HTTP server with testStorage for internal tests.


### PR DESCRIPTION
Replace the iterator-based Subscribe method with a blocking WaitForData method that atomically waits for and returns data. This eliminates correctness issues (silent notification drops, stream deletion looks like timeout) and simplifies both handler code and storage implementations.

Storage interface:
- Subscribe() -> WaitForData(ctx, streamID, offset, limit)
- Uses close-and-replace channel pattern for efficient wake-all notifications
- Returns ErrNotFound explicitly when stream is deleted while waiting

Code organization:
- Extract Offset type to offset.go with Compare, IsZero, FormatOffset, ParseOffset
- Extract StreamConfig methods to config.go (Matches, IsExpired)