### PR TITLE
refactor: reorganize storage packages and use reference offset format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,22 @@ Tested against conformance tests v0.1.8:
 
 Client features: `batching`, `sse`, `longPoll`, `streaming`, `dynamicHeaders`
 
+## Offset Format
+
+This implementation uses the same offset format as the reference Node.js implementation:
+```
+<readSeq>_<byteOffset>
+```
+Both components are 16-digit zero-padded integers, e.g., `0000000000000000_0000000000000042`.
+This ensures lexicographic sortability as required by PROTOCOL.md Section 6.
+
 ## Test Coverage
 
 | Package | Coverage |
 |---------|----------|
 | durablestream | 90.7% |
 | durablestream/transport | 93.1% |
-| durablestream/memorystorage | 96.2% |
+| durablestream/storage/memorystorage | 96.2% |
 | durablestream/internal/protocol | 98.1% |
 
 ## Usage

--- a/durablestream/client_test.go
+++ b/durablestream/client_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/ahimsalabs/durable-streams-go/durablestream"
-	"github.com/ahimsalabs/durable-streams-go/durablestream/memorystorage"
+	"github.com/ahimsalabs/durable-streams-go/durablestream/storage/memorystorage"
 )
 
 // setupTestServer creates a test server with a handler and storage.

--- a/durablestream/example_test.go
+++ b/durablestream/example_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/ahimsalabs/durable-streams-go/durablestream"
-	"github.com/ahimsalabs/durable-streams-go/durablestream/memorystorage"
+	"github.com/ahimsalabs/durable-streams-go/durablestream/storage/memorystorage"
 )
 
 // [snippet:server]

--- a/durablestream/handler_test.go
+++ b/durablestream/handler_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/ahimsalabs/durable-streams-go/durablestream"
 	"github.com/ahimsalabs/durable-streams-go/durablestream/internal/protocol"
-	"github.com/ahimsalabs/durable-streams-go/durablestream/memorystorage"
+	"github.com/ahimsalabs/durable-streams-go/durablestream/storage/memorystorage"
 )
 
 func TestHandler_PUT_CreateStream(t *testing.T) {
@@ -32,7 +32,7 @@ func TestHandler_PUT_CreateStream(t *testing.T) {
 			wantStatus:  http.StatusCreated,
 			wantHeaders: map[string]string{
 				"Content-Type":       "application/octet-stream",
-				"Stream-Next-Offset": "0000000000",
+				"Stream-Next-Offset": "0000000000000000_0000000000000000",
 				"Location":           "http://example.com/test-stream",
 			},
 		},
@@ -359,7 +359,7 @@ func TestHandler_GET_CatchupRead(t *testing.T) {
 		},
 		{
 			name:       "read from offset",
-			offset:     "0000000000",
+			offset:     "0000000000000000_0000000000000000",
 			wantStatus: http.StatusOK,
 		},
 	}
@@ -412,7 +412,7 @@ func TestHandler_GET_JSONMode(t *testing.T) {
 	_, _ = storage.Append(context.Background(), "/stream", []byte(`{"event":"a"}`), "")
 	_, _ = storage.Append(context.Background(), "/stream", []byte(`{"event":"b"}`), "")
 
-	req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+	req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -444,7 +444,7 @@ func TestHandler_GET_LongPoll(t *testing.T) {
 	offset, _ := storage.Append(context.Background(), "/stream", []byte("data1"), "")
 
 	t.Run("immediate return with data", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000&live=long-poll", nil)
+		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000&live=long-poll", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 
@@ -519,7 +519,7 @@ func TestHandler_GET_SSE(t *testing.T) {
 		})
 		_, _ = storage.Append(context.Background(), "/text-stream", []byte("line1\n"), "")
 
-		req := httptest.NewRequest(http.MethodGet, "/text-stream?offset=0000000000&live=sse", nil)
+		req := httptest.NewRequest(http.MethodGet, "/text-stream?offset=0000000000000000_0000000000000000&live=sse", nil)
 		rec := httptest.NewRecorder()
 
 		// Use a timeout to prevent test hanging
@@ -553,7 +553,7 @@ func TestHandler_GET_SSE(t *testing.T) {
 		})
 		_, _ = storage.Append(context.Background(), "/json-stream", []byte(`{"event":"test"}`), "")
 
-		req := httptest.NewRequest(http.MethodGet, "/json-stream?offset=0000000000&live=sse", nil)
+		req := httptest.NewRequest(http.MethodGet, "/json-stream?offset=0000000000000000_0000000000000000&live=sse", nil)
 		rec := httptest.NewRecorder()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
@@ -573,7 +573,7 @@ func TestHandler_GET_SSE(t *testing.T) {
 			ContentType: "application/octet-stream",
 		})
 
-		req := httptest.NewRequest(http.MethodGet, "/binary-stream?offset=0000000000&live=sse", nil)
+		req := httptest.NewRequest(http.MethodGet, "/binary-stream?offset=0000000000000000_0000000000000000&live=sse", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 
@@ -610,7 +610,7 @@ func TestHandler_GET_SSE(t *testing.T) {
 		maliciousPayload := "start\r\revent: control\rdata: {\"cr_injected\":true}\r\rend"
 		_, _ = storage.Append(context.Background(), "/cr-injection-test", []byte(maliciousPayload), "")
 
-		req := httptest.NewRequest(http.MethodGet, "/cr-injection-test?offset=0000000000&live=sse", nil)
+		req := httptest.NewRequest(http.MethodGet, "/cr-injection-test?offset=0000000000000000_0000000000000000&live=sse", nil)
 		rec := httptest.NewRecorder()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
@@ -998,7 +998,7 @@ func TestHandler_CacheControlHeaders(t *testing.T) {
 	_, _ = storage.Append(context.Background(), "/stream", []byte("data"), "")
 
 	t.Run("catch-up read has cache control", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 
@@ -1019,7 +1019,7 @@ func TestHandler_CacheControlHeaders(t *testing.T) {
 	})
 
 	t.Run("public stream has public cache control", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 
@@ -1049,7 +1049,7 @@ func TestHandler_PrivateCacheControl(t *testing.T) {
 	_, _ = storage.Append(context.Background(), "/private-stream", []byte("secret data"), "")
 
 	t.Run("private stream has private cache control", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/private-stream?offset=0000000000", nil)
+		req := httptest.NewRequest(http.MethodGet, "/private-stream?offset=0000000000000000_0000000000000000", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 
@@ -1102,7 +1102,7 @@ func TestHandler_GET_ETagAndIfNoneMatch(t *testing.T) {
 	_, _ = storage.Append(context.Background(), "/stream", []byte("data"), "")
 
 	t.Run("catch-up read returns ETag header", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 
@@ -1122,7 +1122,7 @@ func TestHandler_GET_ETagAndIfNoneMatch(t *testing.T) {
 
 	t.Run("304 Not Modified when If-None-Match matches ETag", func(t *testing.T) {
 		// First request to get the ETag
-		req1 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req1 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		rec1 := httptest.NewRecorder()
 		handler.ServeHTTP(rec1, req1)
 
@@ -1135,7 +1135,7 @@ func TestHandler_GET_ETagAndIfNoneMatch(t *testing.T) {
 		}
 
 		// Second request with If-None-Match should get 304
-		req2 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req2 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		req2.Header.Set("If-None-Match", etag)
 		rec2 := httptest.NewRecorder()
 		handler.ServeHTTP(rec2, req2)
@@ -1157,7 +1157,7 @@ func TestHandler_GET_ETagAndIfNoneMatch(t *testing.T) {
 	})
 
 	t.Run("200 OK when If-None-Match does not match ETag", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		req.Header.Set("If-None-Match", `"wrong-etag"`)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
@@ -1173,14 +1173,14 @@ func TestHandler_GET_ETagAndIfNoneMatch(t *testing.T) {
 
 	t.Run("304 with If-None-Match containing multiple ETags", func(t *testing.T) {
 		// First request to get the ETag
-		req1 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req1 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		rec1 := httptest.NewRecorder()
 		handler.ServeHTTP(rec1, req1)
 
 		etag := rec1.Header().Get("ETag")
 
 		// Request with multiple ETags (one matching)
-		req2 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req2 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		req2.Header.Set("If-None-Match", `"other-etag", `+etag+`, "another-etag"`)
 		rec2 := httptest.NewRecorder()
 		handler.ServeHTTP(rec2, req2)
@@ -1191,7 +1191,7 @@ func TestHandler_GET_ETagAndIfNoneMatch(t *testing.T) {
 	})
 
 	t.Run("304 with If-None-Match wildcard", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		req.Header.Set("If-None-Match", "*")
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
@@ -1203,14 +1203,14 @@ func TestHandler_GET_ETagAndIfNoneMatch(t *testing.T) {
 
 	t.Run("304 with weak ETag (W/ prefix)", func(t *testing.T) {
 		// First request to get the ETag
-		req1 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req1 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		rec1 := httptest.NewRecorder()
 		handler.ServeHTTP(rec1, req1)
 
 		etag := rec1.Header().Get("ETag")
 
 		// Request with weak ETag prefix
-		req2 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req2 := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		req2.Header.Set("If-None-Match", "W/"+etag)
 		rec2 := httptest.NewRecorder()
 		handler.ServeHTTP(rec2, req2)
@@ -1276,7 +1276,7 @@ func TestHandler_GET_ETagAndIfNoneMatch(t *testing.T) {
 
 		// Create request with valid URL, then manually set path to include control char
 		// This simulates what happens when a client sends a URL-encoded null byte
-		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		// Override the path extraction to return the stream path with control chars
 		customHandler := durablestream.NewHandler(storage, &durablestream.HandlerConfig{
 			PathExtractor: func(*http.Request) string { return streamPath },
@@ -1607,7 +1607,7 @@ func BenchmarkHandler_Read(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000", nil)
+		req := httptest.NewRequest(http.MethodGet, "/stream?offset=0000000000000000_0000000000000000", nil)
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 		// Consume body to avoid measurement skew

--- a/durablestream/offset.go
+++ b/durablestream/offset.go
@@ -1,11 +1,6 @@
 // Package durablestream implements the Durable Streams Protocol.
 package durablestream
 
-import (
-	"fmt"
-	"strconv"
-)
-
 // Offset represents an opaque position within a stream.
 // Per spec Section 6: Offsets are opaque tokens that are lexicographically sortable.
 //
@@ -49,30 +44,4 @@ func (o Offset) IsZero() bool {
 // Implements fmt.Stringer interface.
 func (o Offset) String() string {
 	return string(o)
-}
-
-// FormatOffset formats an index as a zero-padded 10-digit string offset.
-// This is a helper for storage implementations that use sequential integer offsets.
-// Uses 10 digits to support up to 9,999,999,999 offsets.
-// Per Section 6: Offsets must be lexicographically sortable and strictly increasing.
-func FormatOffset(idx int64) Offset {
-	return Offset(fmt.Sprintf("%010d", idx))
-}
-
-// ParseOffset parses an offset string back to an index.
-// Returns 0 for empty string or "-1" (stream beginning sentinel).
-// Returns ErrBadRequest for invalid or negative offsets.
-// This is a helper for storage implementations that use sequential integer offsets.
-func ParseOffset(offset Offset) (int64, error) {
-	if offset == "" || offset == "-1" {
-		return 0, nil
-	}
-	idx, err := strconv.ParseInt(string(offset), 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid offset %q: %w", offset, ErrBadRequest)
-	}
-	if idx < 0 {
-		return 0, fmt.Errorf("negative offset %q: %w", offset, ErrBadRequest)
-	}
-	return idx, nil
 }

--- a/durablestream/storage/memorystorage/storage.go
+++ b/durablestream/storage/memorystorage/storage.go
@@ -1,4 +1,7 @@
-// Package memorystorage provides an in-memory implementation of durablestream.Storage.
+// Package memorystore provides an in-memory implementation of durablestream.Storage.
+//
+// This implementation uses the reference offset format from the official Node.js
+// implementation: "<readSeq>_<byteOffset>" with 16-digit zero-padded integers.
 package memorystorage
 
 import (
@@ -7,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/ahimsalabs/durable-streams-go/durablestream"
+	"github.com/ahimsalabs/durable-streams-go/durablestream/storage"
 	"github.com/go4org/hashtriemap"
 )
 
@@ -22,7 +26,10 @@ type memoryStream struct {
 
 // Storage is an in-memory implementation of durablestream.Storage.
 // Uses hashtriemap for lock-free stream lookups with per-stream locks for mutations.
-// Offsets are zero-padded sequential strings (e.g., "0000000001", "0000000002").
+//
+// Offsets use the reference implementation format: "0000000000000000_0000000000000042"
+// where the first 16 digits are the read sequence (always 0 for this implementation)
+// and the second 16 digits are the cumulative byte offset.
 type Storage struct {
 	streams hashtriemap.HashTrieMap[string, *memoryStream]
 }
@@ -99,7 +106,8 @@ func (m *Storage) Append(ctx context.Context, streamID string, data []byte, seq 
 	b := make([]byte, len(data))
 	copy(b, data)
 
-	offset := durablestream.FormatOffset(int64(len(stream.messages) + 1))
+	// Use message index as offset (matching reference implementation's byte offset concept)
+	offset := storage.FormatSimpleOffset(int64(len(stream.messages) + 1))
 	msg := durablestream.StoredMessage{
 		Data:   b,
 		Offset: offset,
@@ -129,10 +137,11 @@ func (m *Storage) Read(ctx context.Context, streamID string, offset durablestrea
 	}
 
 	// Parse offset to message index
-	offsetIdx, err := durablestream.ParseOffset(offset)
+	_, byteOffset, err := storage.ParseOffset(offset)
 	if err != nil {
 		return nil, err
 	}
+	offsetIdx := byteOffset
 
 	// Offset 0 means "start", which maps to first message (index 0)
 	// Offset N means "after message N", so we start reading from index N
@@ -164,7 +173,7 @@ func (m *Storage) Read(ctx context.Context, streamID string, offset durablestrea
 		// No messages returned, stay at current offset
 		nextOffset = offset
 		if nextOffset == "" || nextOffset == "-1" {
-			nextOffset = durablestream.FormatOffset(0)
+			nextOffset = storage.FormatSimpleOffset(0)
 		}
 	}
 
@@ -173,7 +182,7 @@ func (m *Storage) Read(ctx context.Context, streamID string, offset durablestrea
 	if len(stream.messages) > 0 {
 		tailOffset = stream.messages[len(stream.messages)-1].Offset
 	} else {
-		tailOffset = durablestream.FormatOffset(0)
+		tailOffset = storage.FormatSimpleOffset(0)
 	}
 
 	return &durablestream.ReadResult{
@@ -203,7 +212,7 @@ func (m *Storage) Head(ctx context.Context, streamID string) (*durablestream.Str
 	if len(stream.messages) > 0 {
 		nextOffset = stream.messages[len(stream.messages)-1].Offset
 	} else {
-		nextOffset = durablestream.FormatOffset(0)
+		nextOffset = storage.FormatSimpleOffset(0)
 	}
 
 	return &durablestream.StreamInfo{

--- a/durablestream/storage/memorystorage/storage_test.go
+++ b/durablestream/storage/memorystorage/storage_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ahimsalabs/durable-streams-go/durablestream"
+	"github.com/ahimsalabs/durable-streams-go/durablestream/storage"
 )
 
 // concatMessages concatenates all message data from a ReadResult.
@@ -202,7 +203,7 @@ func TestCreate(t *testing.T) {
 			t.Fatalf("append: %v", err)
 		}
 
-		result, err := s.Read(context.Background(), "test", "0000000000", 0)
+		result, err := s.Read(context.Background(), "test", "0000000000000000_0000000000000000", 0)
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
@@ -243,7 +244,7 @@ func TestAppend(t *testing.T) {
 		if err != nil {
 			t.Fatalf("append: %v", err)
 		}
-		if offset != "0000000001" {
+		if offset != "0000000000000000_0000000000000001" {
 			t.Errorf("expected offset 0000000001, got %s", offset)
 		}
 	})
@@ -316,7 +317,7 @@ func TestAppend(t *testing.T) {
 		_, _ = s.Append(context.Background(), "test", []byte(`{"a":1}`), "")
 		_, _ = s.Append(context.Background(), "test", []byte(`{"b":2}`), "")
 
-		result, _ := s.Read(context.Background(), "test", "0000000000", 0)
+		result, _ := s.Read(context.Background(), "test", "0000000000000000_0000000000000000", 0)
 		if len(result.Messages) != 2 {
 			t.Errorf("expected 2 messages, got %d", len(result.Messages))
 		}
@@ -407,7 +408,7 @@ func TestRead(t *testing.T) {
 		_, _ = s.Append(context.Background(), "test", []byte("data"), "")
 
 		// Offset beyond current tail
-		_, err := s.Read(context.Background(), "test", "0000000099", 0)
+		_, err := s.Read(context.Background(), "test", "0000000000000000_0000000000000099", 0)
 		if !errors.Is(err, durablestream.ErrGone) {
 			t.Errorf("expected ErrGone, got: %v", err)
 		}
@@ -433,7 +434,7 @@ func TestRead(t *testing.T) {
 		_, _ = s.Append(context.Background(), "test", []byte("extra"), "")
 
 		// Limit of 8 should return first two messages (10 bytes total, but we return whole messages)
-		result, err := s.Read(context.Background(), "test", "0000000000", 8)
+		result, err := s.Read(context.Background(), "test", "0000000000000000_0000000000000000", 8)
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
@@ -456,7 +457,7 @@ func TestRead(t *testing.T) {
 		_, _ = s.Append(context.Background(), "test", []byte(`{"b":2}`), "")
 		_, _ = s.Append(context.Background(), "test", []byte(`{"c":3}`), "")
 
-		result, err := s.Read(context.Background(), "test", "0000000000", 0)
+		result, err := s.Read(context.Background(), "test", "0000000000000000_0000000000000000", 0)
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
@@ -471,7 +472,7 @@ func TestRead(t *testing.T) {
 		_, _ = s.Append(context.Background(), "test", []byte("msg1"), "")
 		_, _ = s.Append(context.Background(), "test", []byte("msg2"), "")
 
-		result, _ := s.Read(context.Background(), "test", "0000000000", 0)
+		result, _ := s.Read(context.Background(), "test", "0000000000000000_0000000000000000", 0)
 		if result.NextOffset != result.TailOffset {
 			t.Errorf("NextOffset (%s) should equal TailOffset (%s) when at end", result.NextOffset, result.TailOffset)
 		}
@@ -484,7 +485,7 @@ func TestRead(t *testing.T) {
 		_, _ = s.Append(context.Background(), "test", []byte("second"), "")
 
 		// Read from offset 1 (after first message)
-		result, err := s.Read(context.Background(), "test", "0000000001", 0)
+		result, err := s.Read(context.Background(), "test", "0000000000000000_0000000000000001", 0)
 		if err != nil {
 			t.Fatalf("read: %v", err)
 		}
@@ -525,7 +526,7 @@ func TestHead(t *testing.T) {
 		if info.ContentType != "application/json" {
 			t.Errorf("unexpected content type: %s", info.ContentType)
 		}
-		if info.NextOffset != "0000000001" {
+		if info.NextOffset != "0000000000000000_0000000000000001" {
 			t.Errorf("unexpected next offset: %s", info.NextOffset)
 		}
 		if info.TTL != time.Hour {
@@ -779,21 +780,21 @@ func TestWaitForData(t *testing.T) {
 	})
 }
 
-func TestFormatOffset(t *testing.T) {
+func TestFormatSimpleOffset(t *testing.T) {
 	tests := []struct {
 		idx  int64
 		want durablestream.Offset
 	}{
-		{0, "0000000000"},
-		{1, "0000000001"},
-		{123, "0000000123"},
-		{9999999999, "9999999999"},
+		{0, "0000000000000000_0000000000000000"},
+		{1, "0000000000000000_0000000000000001"},
+		{123, "0000000000000000_0000000000000123"},
+		{9999999999, "0000000000000000_0000009999999999"},
 	}
 
 	for _, tt := range tests {
-		got := durablestream.FormatOffset(tt.idx)
+		got := storage.FormatSimpleOffset(tt.idx)
 		if got != tt.want {
-			t.Errorf("FormatOffset(%d) = %s, want %s", tt.idx, got, tt.want)
+			t.Errorf("FormatSimpleOffset(%d) = %s, want %s", tt.idx, got, tt.want)
 		}
 	}
 }
@@ -806,16 +807,16 @@ func TestParseOffset(t *testing.T) {
 	}{
 		{"", 0, false},
 		{"-1", 0, false},
-		{"0000000000", 0, false},
-		{"0000000001", 1, false},
-		{"0000000123", 123, false},
-		{"123", 123, false},  // Without zero-padding
-		{"-5", 0, true},      // Negative offset should error
+		{"0000000000000000_0000000000000000", 0, false},
+		{"0000000000000000_0000000000000001", 1, false},
+		{"0000000000000000_0000000000000123", 123, false},
+		{"0_123", 123, false}, // Without zero-padding
+		{"-5", 0, true},       // Invalid format
 		{"invalid", 0, true},
 	}
 
 	for _, tt := range tests {
-		got, err := durablestream.ParseOffset(tt.offset)
+		_, got, err := storage.ParseOffset(tt.offset)
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("ParseOffset(%q) expected error, got nil", tt.offset)
@@ -941,7 +942,7 @@ func TestConcurrentAccess(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		go func() {
 			for j := 0; j < 100; j++ {
-				_, _ = s.Read(context.Background(), "test", "0000000000", 0)
+				_, _ = s.Read(context.Background(), "test", "0000000000000000_0000000000000000", 0)
 			}
 			done <- struct{}{}
 		}()
@@ -964,7 +965,7 @@ func TestConcurrentAccess(t *testing.T) {
 
 	// Verify data integrity
 	info, _ := s.Head(context.Background(), "test")
-	if info.NextOffset != "0000001000" {
+	if info.NextOffset != "0000000000000000_0000000000001000" {
 		t.Errorf("expected 1000 appends, got offset %s", info.NextOffset)
 	}
 }
@@ -981,7 +982,7 @@ func TestReadWithPartialLimit(t *testing.T) {
 	// Read from start with limit of 6 bytes
 	// With message-based storage, we return whole messages until limit exceeded
 	// First msg (4 bytes) fits, second msg (4+4=8 > 6) exceeds but we have one, stop
-	result, err := s.Read(context.Background(), "test", "0000000000", 6)
+	result, err := s.Read(context.Background(), "test", "0000000000000000_0000000000000000", 6)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -1004,7 +1005,7 @@ func TestReadJSONWithMultipleMessages(t *testing.T) {
 	}
 
 	// Read from middle
-	result, err := s.Read(context.Background(), "test", "0000000002", 0)
+	result, err := s.Read(context.Background(), "test", "0000000000000000_0000000000000002", 0)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}

--- a/durablestream/storage/offset.go
+++ b/durablestream/storage/offset.go
@@ -1,0 +1,79 @@
+// Package storage provides offset formatting helpers for durable stream storage
+// implementations.
+//
+// This package implements offset formatting that matches the reference Node.js
+// implementation at https://github.com/electric-sql/durable-streams.
+//
+// The reference implementation uses the format: <readSeq>_<byteOffset>
+// where both components are 16-digit zero-padded integers. This format ensures
+// offsets are lexicographically sortable as required by PROTOCOL.md Section 6.
+package storage
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ahimsalabs/durable-streams-go/durablestream"
+)
+
+// FormatOffset formats a read sequence and byte offset into a durable stream offset
+// using the reference implementation format: "%016d_%016d".
+//
+// This format is used by the reference Node.js implementation and ensures:
+//   - Lexicographic sortability (zero-padding maintains numeric order)
+//   - Support for very large streams (16 digits = up to 10^16 entries)
+//   - Clear separation of read sequence and byte position
+//
+// Example: FormatOffset(1, 42) returns "0000000000000001_0000000000000042"
+func FormatOffset(readSeq, byteOffset int64) durablestream.Offset {
+	return durablestream.Offset(fmt.Sprintf("%016d_%016d", readSeq, byteOffset))
+}
+
+// ParseOffset parses a durable stream offset back to its read sequence and byte offset.
+//
+// Returns (0, 0, nil) for empty string ("") and "-1" sentinels, which indicate
+// "start of stream" per the protocol.
+//
+// Returns an error wrapped with ErrBadRequest for:
+//   - Invalid format (missing underscore separator)
+//   - Non-numeric components
+//   - Negative values
+func ParseOffset(offset durablestream.Offset) (readSeq, byteOffset int64, err error) {
+	s := string(offset)
+	if s == "" || s == "-1" {
+		return 0, 0, nil
+	}
+
+	parts := strings.SplitN(s, "_", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid offset format %q: expected <readSeq>_<byteOffset>: %w", offset, durablestream.ErrBadRequest)
+	}
+
+	readSeq, err = strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid readSeq in offset %q: %w", offset, durablestream.ErrBadRequest)
+	}
+	if readSeq < 0 {
+		return 0, 0, fmt.Errorf("negative readSeq in offset %q: %w", offset, durablestream.ErrBadRequest)
+	}
+
+	byteOffset, err = strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid byteOffset in offset %q: %w", offset, durablestream.ErrBadRequest)
+	}
+	if byteOffset < 0 {
+		return 0, 0, fmt.Errorf("negative byteOffset in offset %q: %w", offset, durablestream.ErrBadRequest)
+	}
+
+	return readSeq, byteOffset, nil
+}
+
+// FormatSimpleOffset is a helper that formats an offset with readSeq=0.
+// This is useful for simple sequential storage implementations that don't use
+// read sequences, which is the most common case.
+//
+// Example: FormatSimpleOffset(42) returns "0000000000000000_0000000000000042"
+func FormatSimpleOffset(idx int64) durablestream.Offset {
+	return FormatOffset(0, idx)
+}

--- a/durablestream/storage/offset_test.go
+++ b/durablestream/storage/offset_test.go
@@ -1,0 +1,354 @@
+package storage
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/ahimsalabs/durable-streams-go/durablestream"
+)
+
+func TestFormatOffset(t *testing.T) {
+	tests := []struct {
+		name       string
+		readSeq    int64
+		byteOffset int64
+		want       durablestream.Offset
+	}{
+		{
+			name:       "zero values",
+			readSeq:    0,
+			byteOffset: 0,
+			want:       "0000000000000000_0000000000000000",
+		},
+		{
+			name:       "simple values",
+			readSeq:    1,
+			byteOffset: 42,
+			want:       "0000000000000001_0000000000000042",
+		},
+		{
+			name:       "large readSeq",
+			readSeq:    1234567890123456,
+			byteOffset: 0,
+			want:       "1234567890123456_0000000000000000",
+		},
+		{
+			name:       "large byteOffset",
+			readSeq:    0,
+			byteOffset: 9999999999999999,
+			want:       "0000000000000000_9999999999999999",
+		},
+		{
+			name:       "both large",
+			readSeq:    1000000000000000,
+			byteOffset: 2000000000000000,
+			want:       "1000000000000000_2000000000000000",
+		},
+		{
+			name:       "typical message offset",
+			readSeq:    5,
+			byteOffset: 1024,
+			want:       "0000000000000005_0000000000001024",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatOffset(tt.readSeq, tt.byteOffset)
+			if got != tt.want {
+				t.Errorf("FormatOffset(%d, %d) = %q, want %q", tt.readSeq, tt.byteOffset, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseOffset(t *testing.T) {
+	tests := []struct {
+		name           string
+		offset         durablestream.Offset
+		wantReadSeq    int64
+		wantByteOffset int64
+		wantErr        bool
+	}{
+		{
+			name:           "empty string sentinel",
+			offset:         "",
+			wantReadSeq:    0,
+			wantByteOffset: 0,
+			wantErr:        false,
+		},
+		{
+			name:           "-1 sentinel",
+			offset:         "-1",
+			wantReadSeq:    0,
+			wantByteOffset: 0,
+			wantErr:        false,
+		},
+		{
+			name:           "zero values",
+			offset:         "0000000000000000_0000000000000000",
+			wantReadSeq:    0,
+			wantByteOffset: 0,
+			wantErr:        false,
+		},
+		{
+			name:           "simple values",
+			offset:         "0000000000000001_0000000000000042",
+			wantReadSeq:    1,
+			wantByteOffset: 42,
+			wantErr:        false,
+		},
+		{
+			name:           "large values",
+			offset:         "1234567890123456_9876543210987654",
+			wantReadSeq:    1234567890123456,
+			wantByteOffset: 9876543210987654,
+			wantErr:        false,
+		},
+		{
+			name:           "non-padded values still parse",
+			offset:         "1_42",
+			wantReadSeq:    1,
+			wantByteOffset: 42,
+			wantErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReadSeq, gotByteOffset, err := ParseOffset(tt.offset)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseOffset(%q) error = %v, wantErr %v", tt.offset, err, tt.wantErr)
+				return
+			}
+			if gotReadSeq != tt.wantReadSeq {
+				t.Errorf("ParseOffset(%q) readSeq = %d, want %d", tt.offset, gotReadSeq, tt.wantReadSeq)
+			}
+			if gotByteOffset != tt.wantByteOffset {
+				t.Errorf("ParseOffset(%q) byteOffset = %d, want %d", tt.offset, gotByteOffset, tt.wantByteOffset)
+			}
+		})
+	}
+}
+
+func TestParseOffset_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		offset durablestream.Offset
+	}{
+		{
+			name:   "missing underscore",
+			offset: "12345",
+		},
+		{
+			name:   "invalid readSeq",
+			offset: "abc_0000000000000000",
+		},
+		{
+			name:   "invalid byteOffset",
+			offset: "0000000000000000_xyz",
+		},
+		{
+			name:   "negative readSeq",
+			offset: "-1_0000000000000000",
+		},
+		{
+			name:   "negative byteOffset",
+			offset: "0000000000000000_-1",
+		},
+		{
+			name:   "empty parts",
+			offset: "_",
+		},
+		{
+			name:   "too many parts",
+			offset: "1_2_3",
+		},
+		{
+			name:   "overflow readSeq",
+			offset: "99999999999999999999_0",
+		},
+		{
+			name:   "overflow byteOffset",
+			offset: "0_99999999999999999999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := ParseOffset(tt.offset)
+			if err == nil {
+				t.Errorf("ParseOffset(%q) expected error, got nil", tt.offset)
+				return
+			}
+			if !errors.Is(err, durablestream.ErrBadRequest) {
+				t.Errorf("ParseOffset(%q) error = %v, want ErrBadRequest", tt.offset, err)
+			}
+		})
+	}
+}
+
+func TestFormatSimpleOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		idx  int64
+		want durablestream.Offset
+	}{
+		{
+			name: "zero",
+			idx:  0,
+			want: "0000000000000000_0000000000000000",
+		},
+		{
+			name: "simple index",
+			idx:  42,
+			want: "0000000000000000_0000000000000042",
+		},
+		{
+			name: "large index",
+			idx:  9999999999999999,
+			want: "0000000000000000_9999999999999999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatSimpleOffset(tt.idx)
+			if got != tt.want {
+				t.Errorf("FormatSimpleOffset(%d) = %q, want %q", tt.idx, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatOffset_RoundTrip(t *testing.T) {
+	testCases := []struct {
+		readSeq    int64
+		byteOffset int64
+	}{
+		{0, 0},
+		{1, 1},
+		{0, 1000000},
+		{1000000, 0},
+		{12345, 67890},
+		{9999999999999999, 9999999999999999},
+	}
+
+	for _, tc := range testCases {
+		offset := FormatOffset(tc.readSeq, tc.byteOffset)
+		gotReadSeq, gotByteOffset, err := ParseOffset(offset)
+		if err != nil {
+			t.Errorf("RoundTrip(%d, %d) ParseOffset error: %v", tc.readSeq, tc.byteOffset, err)
+			continue
+		}
+		if gotReadSeq != tc.readSeq || gotByteOffset != tc.byteOffset {
+			t.Errorf("RoundTrip(%d, %d): got (%d, %d)", tc.readSeq, tc.byteOffset, gotReadSeq, gotByteOffset)
+		}
+	}
+}
+
+func TestOffset_LexicographicSortability(t *testing.T) {
+	offsets := []durablestream.Offset{
+		FormatOffset(2, 100),
+		FormatOffset(0, 0),
+		FormatOffset(1, 50),
+		FormatOffset(0, 100),
+		FormatOffset(1, 0),
+		FormatOffset(0, 1),
+	}
+
+	sorted := make([]string, len(offsets))
+	for i, o := range offsets {
+		sorted[i] = string(o)
+	}
+	sort.Strings(sorted)
+
+	expected := []string{
+		string(FormatOffset(0, 0)),
+		string(FormatOffset(0, 1)),
+		string(FormatOffset(0, 100)),
+		string(FormatOffset(1, 0)),
+		string(FormatOffset(1, 50)),
+		string(FormatOffset(2, 100)),
+	}
+
+	for i := range sorted {
+		if sorted[i] != expected[i] {
+			t.Errorf("Lexicographic sort failed at index %d: got %q, want %q", i, sorted[i], expected[i])
+		}
+	}
+}
+
+func TestOffset_LexicographicSortability_ByteOffsetOnly(t *testing.T) {
+	offsets := []durablestream.Offset{
+		FormatSimpleOffset(100),
+		FormatSimpleOffset(1),
+		FormatSimpleOffset(10),
+		FormatSimpleOffset(2),
+		FormatSimpleOffset(0),
+	}
+
+	sorted := make([]string, len(offsets))
+	for i, o := range offsets {
+		sorted[i] = string(o)
+	}
+	sort.Strings(sorted)
+
+	expected := []int64{0, 1, 2, 10, 100}
+	for i, exp := range expected {
+		want := string(FormatSimpleOffset(exp))
+		if sorted[i] != want {
+			t.Errorf("Simple offset sort failed at index %d: got %q, want %q", i, sorted[i], want)
+		}
+	}
+}
+
+func TestOffset_Compare(t *testing.T) {
+	tests := []struct {
+		name string
+		a    durablestream.Offset
+		b    durablestream.Offset
+		want int
+	}{
+		{
+			name: "equal offsets",
+			a:    FormatOffset(1, 100),
+			b:    FormatOffset(1, 100),
+			want: 0,
+		},
+		{
+			name: "different readSeq",
+			a:    FormatOffset(1, 100),
+			b:    FormatOffset(2, 100),
+			want: -1,
+		},
+		{
+			name: "different byteOffset",
+			a:    FormatOffset(1, 100),
+			b:    FormatOffset(1, 200),
+			want: -1,
+		},
+		{
+			name: "readSeq takes precedence",
+			a:    FormatOffset(1, 999),
+			b:    FormatOffset(2, 1),
+			want: -1,
+		},
+		{
+			name: "reversed comparison",
+			a:    FormatOffset(2, 100),
+			b:    FormatOffset(1, 100),
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.a.Compare(tt.b)
+			if got != tt.want {
+				t.Errorf("Compare(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/durablestream/storage_mock_test.go
+++ b/durablestream/storage_mock_test.go
@@ -4,9 +4,31 @@ import (
 	"context"
 	"fmt"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"time"
 )
+
+// formatTestOffset formats an offset for testing using the reference implementation format.
+// This is a local helper to avoid importing the storage package (which would create a cycle).
+func formatTestOffset(idx int64) Offset {
+	return Offset(fmt.Sprintf("0000000000000000_%016d", idx))
+}
+
+// parseTestOffset parses a test offset to get the byte offset.
+func parseTestOffset(offset Offset) int64 {
+	s := string(offset)
+	if s == "" || s == "-1" {
+		return 0
+	}
+	parts := strings.SplitN(s, "_", 2)
+	if len(parts) != 2 {
+		return 0
+	}
+	var idx int64
+	fmt.Sscanf(parts[1], "%d", &idx)
+	return idx
+}
 
 // testStorage is a minimal storage implementation for internal tests.
 // It provides basic functionality without importing external packages.
@@ -59,7 +81,7 @@ func (s *testStorage) Append(ctx context.Context, streamID string, data []byte, 
 	b := make([]byte, len(data))
 	copy(b, data)
 
-	offset := FormatOffset(int64(len(stream.messages) + 1))
+	offset := formatTestOffset(int64(len(stream.messages) + 1))
 	msg := StoredMessage{
 		Data:   b,
 		Offset: offset,
@@ -82,10 +104,7 @@ func (s *testStorage) Read(ctx context.Context, streamID string, offset Offset, 
 		return nil, ErrNotFound
 	}
 
-	offsetIdx := 0
-	if offset != "" && offset != "-1" {
-		_, _ = fmt.Sscanf(string(offset), "%d", &offsetIdx)
-	}
+	offsetIdx := int(parseTestOffset(offset))
 
 	if offsetIdx > len(stream.messages) {
 		return nil, ErrGone
@@ -110,7 +129,7 @@ func (s *testStorage) Read(ctx context.Context, streamID string, offset Offset, 
 	} else {
 		nextOffset = offset
 		if nextOffset == "" || nextOffset == "-1" {
-			nextOffset = FormatOffset(0)
+			nextOffset = formatTestOffset(0)
 		}
 	}
 
@@ -119,7 +138,7 @@ func (s *testStorage) Read(ctx context.Context, streamID string, offset Offset, 
 	if len(stream.messages) > 0 {
 		tailOffset = stream.messages[len(stream.messages)-1].Offset
 	} else {
-		tailOffset = FormatOffset(0)
+		tailOffset = formatTestOffset(0)
 	}
 
 	return &ReadResult{
@@ -142,7 +161,7 @@ func (s *testStorage) Head(ctx context.Context, streamID string) (*StreamInfo, e
 	if len(stream.messages) > 0 {
 		nextOffset = stream.messages[len(stream.messages)-1].Offset
 	} else {
-		nextOffset = FormatOffset(0)
+		nextOffset = formatTestOffset(0)
 	}
 
 	return &StreamInfo{


### PR DESCRIPTION
- Move memorystorage to durablestream/storage/memorystorage
- Add durablestream/storage package with offset helpers
- Offset format now matches reference: "0000000000000000_0000000000000042" (16-digit zero-padded readSeq_byteOffset)
- Remove FormatOffset/ParseOffset from main durablestream package
- Update all tests and examples to use new package paths